### PR TITLE
feat: add --wp-version flag to cove add

### DIFF
--- a/commands/add
+++ b/commands/add
@@ -3,10 +3,11 @@ cove_add() {
     local site_name="$1"
     local site_type="wordpress"
     local no_reload_flag=false
+    local wp_version=""
 
     if [ -z "$site_name" ]; then
         gum style --foreground red "❌ Error: A site name is required."
-        echo "Usage: cove add <name> [--plain]"
+        echo "Usage: cove add <name> [--plain] [--wp-version=<version>]"
         exit 1
     fi
 
@@ -30,7 +31,15 @@ cove_add() {
         if [ "$arg" == "--no-reload" ]; then
             no_reload_flag=true
         fi
+        if [[ "$arg" == --wp-version=* ]]; then
+            wp_version="${arg#*=}"
+        fi
     done
+
+    if [ -n "$wp_version" ] && ! [[ "$wp_version" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+        gum style --foreground red "❌ Error: Invalid WordPress version '$wp_version'." "Use a numeric version like 6.4 or 6.4.3."
+        exit 1
+    fi
 
     for protected_name in $PROTECTED_NAMES; do
         if [ "$site_name" == "$protected_name" ]; then
@@ -63,7 +72,10 @@ cove_add() {
         source_config
         local db_name
         db_name=$(echo "cove_$site_name" | tr -c '[:alnum:]_' '_')
-        
+
+        if [ -n "$wp_version" ]; then
+            echo "📌 Targeting WordPress $wp_version"
+        fi
         echo "🗄️ Creating database: $db_name"
         mysql -u "$DB_USER" -p"$DB_PASSWORD" -e "CREATE DATABASE IF NOT EXISTS \`$db_name\`;"
         echo "Installing WordPress..."
@@ -85,7 +97,9 @@ cove_add() {
             cd "$site_dir/public" || exit 1
 
             # 1. Download WordPress with a higher memory limit
-            if ! $wp_cmd core download --quiet; then
+            local version_arg=""
+            [ -n "$wp_version" ] && version_arg="--version=$wp_version"
+            if ! $wp_cmd core download --quiet $version_arg; then
                 echo "❌ Error: Failed to download WordPress core. This might be a network issue or a permissions problem."
                 exit 1 # Exit the subshell with an error
             fi

--- a/main
+++ b/main
@@ -2173,7 +2173,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         case 'add_site':
             if (!empty($site_name) && preg_match('/^[a-zA-Z0-9-]+$/', $site_name)) {
                 $type_flag = ($input['is_plain'] ?? false) ? '--plain' : '';
-                $command = sprintf('HOME=%s %s add %s %s --no-reload 2>&1', escapeshellarg($user_home), escapeshellarg($cove_path), escapeshellarg($site_name), $type_flag);
+                $version_flag = '';
+                if (!empty($input['wp_version']) && preg_match('/^\d+\.\d+(\.\d+)?$/', $input['wp_version'])) {
+                    $version_flag = ' --wp-version=' . escapeshellarg($input['wp_version']);
+                }
+                $command = sprintf('HOME=%s %s add %s %s %s --no-reload 2>&1', escapeshellarg($user_home), escapeshellarg($cove_path), escapeshellarg($site_name), $type_flag, $version_flag);
                 // Remember we're adding so the post-exec block below can
                 // measure the new site's size and fold it into the cache.
                 $add_site_target = $site_name;
@@ -2647,6 +2651,7 @@ $__cove_port_suffix = ($__cove_https_port === 443) ? '' : ':' . $__cove_https_po
         .add-row input[type="text"]:focus { outline: 0; border-color: var(--accent); }
         .add-row .plain-toggle { display: inline-flex; align-items: center; gap: 0.4rem; color: var(--text-dim); font-size: 0.85rem; cursor: pointer; }
         .add-row .plain-toggle input { accent-color: var(--accent); }
+        .add-row input.wp-version { min-width: 0; width: 170px; flex: none; }
 
         /* Site list — one grid on the <ul>, rows inherit its columns via
            subgrid so type/modified/size/actions align vertically across rows
@@ -2919,6 +2924,7 @@ $__cove_port_suffix = ($__cove_https_port === 443) ? '' : ':' . $__cove_https_po
                         <input type="checkbox" x-model="newSite.isPlain" :disabled="newSite.isLoading">
                         plain (no WordPress)
                     </label>
+                    <input type="text" class="wp-version" x-show="!newSite.isPlain" x-model="newSite.wpVersion" placeholder="WP version (e.g. 6.4.3)" pattern="\d+\.\d+(\.\d+)?" title="Numeric version like 6.4 or 6.4.3" :disabled="newSite.isLoading || newSite.isPlain">
                     <button class="pill primary" type="submit" :disabled="!newSite.name || newSite.isLoading">
                         <span class="btn-spinner" x-show="newSite.isLoading" aria-hidden="true" style="display: none;"></span>
                         <span x-text="newSite.isLoading ? 'creating…' : 'create'"></span>
@@ -3142,7 +3148,7 @@ $__cove_port_suffix = ($__cove_https_port === 443) ? '' : ':' . $__cove_https_po
                 rename: { open: false, site: null, value: '', busy: false },
                 logView: { open: false, site: '', text: '', truncated: false, busy: false, raw: false },
                 _initialised: false,
-                newSite: { name: '', isPlain: false, isLoading: false },
+                newSite: { name: '', isPlain: false, wpVersion: '', isLoading: false },
                 snackbar: { visible: false, message: '', isError: false, timer: null, action: null, actionLabel: '' },
                 // Deletes are staged for a short undo window before anything is
                 // sent to the backend. One batch at a time; staging more sites
@@ -3710,8 +3716,9 @@ $__cove_port_suffix = ($__cove_https_port === 443) ? '' : ':' . $__cove_https_po
                     this.newSite.isLoading = true;
                     const name = this.newSite.name;
                     const isPlain = this.newSite.isPlain;
+                    const wpVersion = this.newSite.isPlain ? '' : this.newSite.wpVersion.trim();
 
-                    const add = await this.apiPost('add_site', { site_name: name, is_plain: isPlain });
+                    const add = await this.apiPost('add_site', { site_name: name, is_plain: isPlain, wp_version: wpVersion || undefined });
                     if (add.success) {
                         // Optimistic insert: we already know every field the row
                         // template uses. No auto-refresh — the Caddy reload that
@@ -3733,6 +3740,7 @@ $__cove_port_suffix = ($__cove_https_port === 443) ? '' : ':' . $__cove_https_po
                         });
                         this.showSnack('Site created.');
                         this.newSite.name = '';
+                        this.newSite.wpVersion = '';
                         this.adding = false;
                         this.apiPost('reload_server'); // fire and forget — Caddy reloads in the background
 
@@ -4053,7 +4061,7 @@ display_command_help() {
             echo "  --totals       Calculates and displays the size of each site's public directory."
             ;;
         add)
-            echo "Usage: cove add <name> [--plain]"
+            echo "Usage: cove add <name> [--plain] [--wp-version=<version>]"
             echo ""
             echo "Creates a new local site accessible at 'https://<name>.localhost'."
             echo ""
@@ -4061,7 +4069,8 @@ display_command_help() {
             echo "  <name>         The name for the new site. Becomes the subdomain."
             echo ""
             echo "Flags:"
-            echo "  --plain        Creates a new static HTML site without a database."
+            echo "  --plain                Creates a new static HTML site without a database."
+            echo "  --wp-version=<version> Download a specific WordPress version (e.g. 6.4.3)."
             ;;
         delete)
             echo "Usage: cove delete <name> [--force]"

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ Cove provides a simple set of commands to manage your local environment.
 
 | Command | Description |
 | --- | --- |
-| `cove add <name> [--plain]` | Creates a new WordPress site (`<name>.localhost`). Use `--plain` for a static site. |
+| `cove add <name> [--plain] [--wp-version=<version>]` | Creates a new WordPress site (`<name>.localhost`). Use `--plain` for a static site, `--wp-version` to install a specific WordPress version. |
 | `cove delete <name> [--force]` | Deletes a site's directory and its associated database. |
 | `cove rename <old-name> <new-name>` | Renames a site, its directory, database, and runs `wp search-replace` so stored URLs (siteurl, home, serialized content) all update to the new domain. |
 | `cove list [--totals]` | Lists all sites managed by Cove. Use `--totals` to show disk usage. |


### PR DESCRIPTION
Allows installing a specific WordPress version via `cove add <name> --wp-version=6.4.3`. When omitted, the latest version is downloaded (existing behavior unchanged). Invalid versions are rejected up front with a clear error.

Also adds a version input to the dashboard's add-site form, visible only when creating a WordPress site.